### PR TITLE
Update checksum and upstream URL

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/tulir/mautrix-signal/archive/v0.1.1.tar.gz
-SOURCE_SUM=92b85eab45d9d2d165298b114a5ee47bb89f93a2c6bfa7a30a3d6a1bac4870b3
+SOURCE_URL=https://github.com/mautrix/mautrix-signal/archive/v0.1.1.tar.gz
+SOURCE_SUM=a8c0ff6e94d20a223f0969cd729cc533b0493ade128ba811512481f99c36cd67
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true


### PR DESCRIPTION


## Problem
Upstream URL changed, this is mentioned in this week's edition of TWIM:
https://matrix.org/blog/2021/08/06/this-week-in-matrix-2021-08-06#mautrix-

Regarding the checksum, I am unsure what changed, but the previous one was invalid,
either at the new URL or the old one. Closes #10.

## Solution
Changed both package checksum and upstream URL.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mautrix_signal_ynh%20PR-NUM-%20(USERNAME)/)  
